### PR TITLE
Fix quick start yaml snippets

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -86,7 +86,7 @@ spec:
         allowCidrs: 127.0.0.1,::1,{{ index .Cluster.spec.clusterNetwork.pods.cidrBlocks 0 }}
 ```
 
-We use the `clusterSelector` to select the workload cluster to install the chart to. In this case, we install the chart to any workload cluster with the label `nginxIngressChart: enabled`.
+We use the `clusterSelector` to select the workload cluster to install the chart to. In this case, we install the chart to any workload cluster with the label `nginxIngressChart: enabled` found in the same namespace as `HelmChartProxy` resource. To provide specific namespace to install the chart to set `spec.namespace` field.
 
 The `repoURL` and `chartName` are used to specify the chart to install. The `valuesTemplate` is used to specify the values to use when installing the chart. It supports Go templating, and here we set `controller.name` to the name of the selected cluster + `-nginx`. We also set `controller.nginxStatus.allowCidrs` to include the first entry in the workload cluster's pod CIDR blocks.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -81,9 +81,9 @@ spec:
   chartName: nginx-ingress
   valuesTemplate: |
     controller:
-      name: "{{ .Cluster.Name }}-nginx"
+      name: "{{ .ControlPlane.metadata.name }}-nginx"
       nginxStatus:
-        allowCidrs: 127.0.0.1,::1,{{ index .Cluster.Spec.ClusterNetwork.Pods.CIDRBlocks 0 }}
+        allowCidrs: 127.0.0.1,::1,{{ index .Cluster.spec.clusterNetwork.pods.cidrBlocks 0 }}
 ```
 
 We use the `clusterSelector` to select the workload cluster to install the chart to. In this case, we install the chart to any workload cluster with the label `nginxIngressChart: enabled`.


### PR DESCRIPTION
This PR fixes go templates provided in the quick-start guide. The correct go-templates can be found in https://github.com/Jont828/cluster-api-addon-provider-helm/blob/main/config/samples/nginx-ingress.yaml 

I've also included a note about namespaces. `spec.namespace` is implementation specific and just from reading the doc you can't guess is this functionality is provided and if yes what's the name of the field, e.g FluxCD uses `.spec.targetNamespace` for the same purpose. 
`clusterSelector` bit is obvious in retrospect because this is how this works in all other use cases: netpols, svc, etc - it only selects resources in the same namespace but I think there is no harm in highlighting this explicitly. If this doesn't read well I am happy to revert this commit.